### PR TITLE
Use libtest_mimic to run gix-url fixture tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2348,6 +2348,7 @@ dependencies = [
  "gix-path 0.8.4",
  "gix-testtools",
  "home",
+ "libtest-mimic",
  "serde",
  "thiserror",
  "url",
@@ -2909,6 +2910,17 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libtest-mimic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8de370f98a6cb8a4606618e53e802f93b094ddec0f96988eaec2c27e6e9ce7"
+dependencies = [
+ "clap",
+ "termcolor",
+ "threadpool",
 ]
 
 [[package]]
@@ -4100,6 +4112,15 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/gix-url/Cargo.toml
+++ b/gix-url/Cargo.toml
@@ -12,6 +12,10 @@ rust-version = "1.65"
 [lib]
 doctest = false
 
+[[test]]
+name = "baseline"
+harness = false
+
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde = ["dep:serde", "bstr/serde"]
@@ -30,6 +34,7 @@ document-features = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 gix-testtools = { path = "../tests/tools" }
+libtest-mimic = "0.6.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/gix-url/tests/url.rs
+++ b/gix-url/tests/url.rs
@@ -2,6 +2,5 @@ pub type Error = Box<dyn std::error::Error>;
 pub type Result = std::result::Result<(), Error>;
 
 mod access;
-mod baseline;
 mod expand_path;
 mod parse;


### PR DESCRIPTION
I wanted fancy nextest output and it turns out getting it is simpler than I originally thought.

Running `cargo nextest run --package gix-url --test baseline --no-fail-fast` the following output is generated:

![Screenshot from 2023-08-07 18-21-17](https://github.com/niklaswimmer/gitoxide/assets/51296580/6eafe77c-9c03-4b97-bf46-4977f1f7daf2)

Running `cargo nextest run --all --no-fail-fast` produces the following output (i.e. it treats them as tests on the same level as all the other tests):

![image](https://github.com/niklaswimmer/gitoxide/assets/51296580/9caaa39e-3fad-4a29-a40e-87e764c3564f)
